### PR TITLE
Automatic update of IntegrationTests.ManifestUpdate.OneInstallerCreate from 1.0 to 2.0

### DIFF
--- a/manifests/IntegrationTests/ManifestUpdate/OneInstallerCreate/2.0.yaml
+++ b/manifests/IntegrationTests/ManifestUpdate/OneInstallerCreate/2.0.yaml
@@ -1,0 +1,11 @@
+Id: IntegrationTests.ManifestUpdate.OneInstallerCreate
+Version: 1.0
+Name: ManifestUpdate Test
+Publisher: Contoso
+Description: Manifest update test for Create
+License: Text
+Installers: 
+    - Arch: x64
+      Url: https://stpkgmanvalwestustest.blob.core.windows.net/test-installers/VSCodeUserSetup-x64-1.46.1.exe
+      InstallerType: inno
+      Sha256: e29f73f5b6bad9ea5a484d9a934141a03d3fa39c55efd6e65e6e02dea6be9aa5

--- a/manifests/IntegrationTests/ManifestUpdate/OneInstallerCreate/2.0.yaml
+++ b/manifests/IntegrationTests/ManifestUpdate/OneInstallerCreate/2.0.yaml
@@ -1,11 +1,12 @@
+# Automatically updated by the winget bot at 2021/Mar/20
 Id: IntegrationTests.ManifestUpdate.OneInstallerCreate
-Version: 1.0
+Version: 2.0
 Name: ManifestUpdate Test
 Publisher: Contoso
 Description: Manifest update test for Create
 License: Text
-Installers: 
-    - Arch: x64
-      Url: https://stpkgmanvalwestustest.blob.core.windows.net/test-installers/VSCodeUserSetup-x64-1.46.1.exe
-      InstallerType: inno
-      Sha256: e29f73f5b6bad9ea5a484d9a934141a03d3fa39c55efd6e65e6e02dea6be9aa5
+Installers:
+- Arch: x64
+  Url: https://stpkgmanvalwestustest.blob.core.windows.net/test-installers/VSCodeUserSetup-x64-1.46.1.exe
+  InstallerType: inno
+  Sha256: 7777777777777777777777777777777777777777777777777777777777777777


### PR DESCRIPTION
Automation detected that manifest IntegrationTests.ManifestUpdate.OneInstallerCreate needs to be updated.
Reason:
- Installer(s) found with hash mismatch.