### PR TITLE
Automatic update of IntegrationTests.ManifestUpdate.OneInstallerModify 1.0

### DIFF
--- a/manifests/IntegrationTests/ManifestUpdate/OneInstallerModify/1.0.yaml
+++ b/manifests/IntegrationTests/ManifestUpdate/OneInstallerModify/1.0.yaml
@@ -1,11 +1,12 @@
+# Automatically updated by the winget bot at 2021/Mar/20
 Id: IntegrationTests.ManifestUpdate.OneInstallerModify
 Version: 1.0
 Name: ManifestUpdate Test
 Publisher: Contoso
 Description: Test manifest update modify
 License: Text
-Installers: 
-    - Arch: x64
-      Url: https://stpkgmanvalwestustest.blob.core.windows.net/test-installers/VSCodeUserSetup-x64-1.46.1.exe
-      InstallerType: inno
-      Sha256: e29f73f5b6bad9ea5a484d9a934141a03d3fa39c55efd6e65e6e02dea6be9aa5
+Installers:
+- Arch: x64
+  Url: https://stpkgmanvalwestustest.blob.core.windows.net/test-installers/VSCodeUserSetup-x64-1.46.1.exe
+  InstallerType: inno
+  Sha256: 6666666666666666666666666666666666666666666666666666666666666666


### PR DESCRIPTION
Automation detected that manifest IntegrationTests.ManifestUpdate.OneInstallerModify needs to be updated.
Reason:
- Installer(s) found with hash mismatch.