### PR TITLE
Automatic update of Logitech.LGH from latest to 2020.12.3534

### DIFF
--- a/manifests/Logitech/LGH/2020.12.3534.yaml
+++ b/manifests/Logitech/LGH/2020.12.3534.yaml
@@ -1,0 +1,20 @@
+Id: Logitech.LGH
+Publisher: Logitech
+Name: Logitech Gaming Hub
+Author: Logitech
+Description: Customize Logitech G gaming mice, keyboards, headsets, speakers, and other devices
+AppMoniker: lghub
+Tags: "mouse, keyboard, headset, driver"
+Homepage: https://gaming.logicool.co.jp/en-US/innovation/g-hub.html
+License: Copyright (c) Logitech, Inc. 2020
+LicenseUrl: https://secure.logitech.com/en-us/footer/terms-of-use
+MinOSVersion: 10.0.0.0
+Version: latest
+InstallerType: exe
+Installers:
+  - Switches:
+      Silent:
+      SilentWithProgress:
+    Arch: x64
+    Url: https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe
+    Sha256: f188ec2eb1bd04e54c36e976e15fea1812b3a40af52a500b4782b7f0c3994364

--- a/manifests/Logitech/LGH/2020.12.3534.yaml
+++ b/manifests/Logitech/LGH/2020.12.3534.yaml
@@ -1,3 +1,4 @@
+# Automatically updated by the winget bot at 2021/Mar/20
 Id: Logitech.LGH
 Publisher: Logitech
 Name: Logitech Gaming Hub
@@ -9,12 +10,12 @@ Homepage: https://gaming.logicool.co.jp/en-US/innovation/g-hub.html
 License: Copyright (c) Logitech, Inc. 2020
 LicenseUrl: https://secure.logitech.com/en-us/footer/terms-of-use
 MinOSVersion: 10.0.0.0
-Version: latest
+Version: 2020.12.3534
 InstallerType: exe
 Installers:
-  - Switches:
-      Silent:
-      SilentWithProgress:
-    Arch: x64
-    Url: https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe
-    Sha256: f188ec2eb1bd04e54c36e976e15fea1812b3a40af52a500b4782b7f0c3994364
+- Switches:
+    Silent: ''
+    SilentWithProgress: ''
+  Arch: x64
+  Url: https://download01.logi.com/web/ftp/pub/techsupport/gaming/lghub_installer.exe
+  Sha256: C7BCDD038DDC701D8C364ED4E62A5F5739F75780BAA6C14B3264BA345022615C


### PR DESCRIPTION
Automation detected that manifest Logitech.LGH needs to be updated.
Reason:
- Installer(s) found with hash mismatch.